### PR TITLE
Extended run command functionality with more flags and options

### DIFF
--- a/run
+++ b/run
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 WHITE='\033[0;37m'
@@ -7,27 +6,42 @@ NC='\033[0m'
 
 FILE=""
 USEFILE=true
+IN_FILE="in.txt"
 SIMPLE=false
 
-while getopts f:ish option
+# Detect the platform (similar to $OSTYPE)
+DATE_MOD="+%s%N"
+  
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	DATE_MOD="+%s000"
+fi
+
+while getopts f:i:sh option
 do
 	case "$option" in
 		f)
 			FILE="$OPTARG" ;;
 		i)
+			IN_FILE="$OPTARG";;
+		u)
 			USEFILE=false ;;
 		s)
 			SIMPLE=true ;;
 		\? | h)
 			echo -e "\\nUsage: run -f [FILENAME] [options]"
-			echo -e "\\t-i\\tUse stdin instead of 'in.txt' as input"
+			echo -e "\\t-i\\tSpecify the input file to use"
+			echo -e "\\t-u\\tUse stdin instead of '$IN_FILE' as input"
 			echo -e "\\t-s\\tDo a simple compile and execute"
 			echo -e "\\t-h\\tShow usage\\n"
 	esac
 done
 
 if [[ "$FILE" == "" ]]; then
-	echo -e "${RED}Error: no file specified"
+	echo -e "${RED}Error: no source file specified"
+fi
+
+if [[ "$FILE" == "" ]]; then
+	echo -e "${RED}Error: no input file specified"
 fi
 
 EXTENSION="${FILE##*.}"
@@ -47,16 +61,14 @@ RunJava()
 
 	START_TIME=0
 	if [[ "$USEFILE" == true ]]; then
-		START_TIME=$(($(date +%s%N)/1000000))
-		java "$NAME" < in.txt
+		START_TIME=$(($(date $DATE_MOD)/1000000))
+		java "$NAME" < "$IN_FILE"
 	else
-		START_TIME=$(($(date +%s%N)/1000000))
-		java "$NAME"
+		START_TIME=$(($(date $DATE_MOD)/1000000))
+		java "$NAME" < "$IN_FILE"
 	fi
-	END_TIME=$(($(date +%s%N)/1000000))
-
+	END_TIME=$(($(date $DATE_MOD)/1000000))
 	ELAPSED_TIME=$(($END_TIME - $START_TIME))
-
 	echo -e "${GREEN}Runtime: ${ELAPSED_TIME} ms"
 
 	echo -e "${GREEN}Removing class file..."

--- a/run
+++ b/run
@@ -7,6 +7,7 @@ NC='\033[0m'
 FILE=""
 USEFILE=true
 IN_FILE="in.txt"
+OUT_FILE=""
 SIMPLE=false
 JUST_RUN=false
 
@@ -17,13 +18,15 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 	DATE_COMMAND="gdate"
 fi
 
-while getopts f:i:shur option
+while getopts f:i:o:shur option
 do
 	case "$option" in
 		f)
 			FILE="$OPTARG" ;;
 		i)
 			IN_FILE="$OPTARG" ;;
+		o)
+			OUT_FILE="$OPTARG" ;;
 		u)
 			USEFILE=false ;;
 		r)
@@ -33,6 +36,7 @@ do
 		\? | h)
 			echo -e "\\nUsage: run -f [FILENAME] [options]"
 			echo -e "\\t-i\\tSpecify the input file to use"
+			echo -e "\\t-o\\tSpecify an expected output file to diff stdout with"
 			echo -e "\\t-u\\tUse stdin instead of '$IN_FILE' as input"
 			echo -e "\\t-s\\tDo a simple compile and execute"
 			echo -e "\\t-r\\tSkip compilation and just run the class"
@@ -66,16 +70,22 @@ RunJava()
 	fi
 
 	START_TIME=0
+	OUTPUT=""
 	if [[ "$USEFILE" == true ]]; then
 		START_TIME=$(($($DATE_COMMAND +%s%N)/1000000))
-		java "$NAME" < "$IN_FILE"
+		OUTPUT=$(java "$NAME" < "$IN_FILE")
 	else
 		START_TIME=$(($($DATE_COMMAND +%s%N)/1000000))
-		java "$NAME"
+		OUTPUT=$(java "$NAME")
 	fi
+	echo -e "$OUTPUT"
 	END_TIME=$(($($DATE_COMMAND +%s%N)/1000000))
 	ELAPSED_TIME=$(($END_TIME - $START_TIME))
 	echo -e "${GREEN}Runtime: ${ELAPSED_TIME} ms"
+	if [[ "$OUT_FILE" != "" ]]; then
+		echo -e "${GREEN}Checking difference with output file${WHITE}"
+		echo "$OUTPUT" | diff - "$OUT_FILE"
+	fi
 	echo -e "${GREEN}Removing class file..."
 	rm *.class
 }

--- a/run
+++ b/run
@@ -8,6 +8,7 @@ FILE=""
 USEFILE=true
 IN_FILE="in.txt"
 SIMPLE=false
+JUST_RUN=false
 
 # Detect the platform (similar to $OSTYPE)
 DATE_COMMAND="date"
@@ -16,15 +17,17 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 	DATE_COMMAND="gdate"
 fi
 
-while getopts f:i:shu option
+while getopts f:i:shur option
 do
 	case "$option" in
 		f)
 			FILE="$OPTARG" ;;
 		i)
-			IN_FILE="$OPTARG";;
+			IN_FILE="$OPTARG" ;;
 		u)
 			USEFILE=false ;;
+		r)
+			JUST_RUN=true ;;
 		s)
 			SIMPLE=true ;;
 		\? | h)
@@ -32,6 +35,7 @@ do
 			echo -e "\\t-i\\tSpecify the input file to use"
 			echo -e "\\t-u\\tUse stdin instead of '$IN_FILE' as input"
 			echo -e "\\t-s\\tDo a simple compile and execute"
+			echo -e "\\t-r\\tSkip compilation and just run the class"
 			echo -e "\\t-h\\tShow usage\\n"
 	esac
 done
@@ -49,8 +53,10 @@ NAME="${FILE%.*}"
 
 RunJava()
 {
-	echo -e "${GREEN}Compiling...${WHITE}"
-	javac "$FILE"
+	if [[ "$JUST_RUN" != true ]]; then
+		echo -e "${GREEN}Compiling...${WHITE}"
+		javac "$FILE"
+	fi
 
 	echo -e "${GREEN}Running...${WHITE}"
 
@@ -72,7 +78,6 @@ RunJava()
 	echo -e "${GREEN}Runtime: ${ELAPSED_TIME} ms"
 	echo -e "${GREEN}Removing class file..."
 	rm *.class
-	echo -e "${GREEN}Done"
 }
 
 if [[ "$EXTENSION" == "java" ]]; then

--- a/run
+++ b/run
@@ -10,13 +10,13 @@ IN_FILE="in.txt"
 SIMPLE=false
 
 # Detect the platform (similar to $OSTYPE)
-DATE_MOD="+%s%N"
+DATE_COMMAND="date"
   
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	DATE_MOD="+%s000"
+	DATE_COMMAND="gdate"
 fi
 
-while getopts f:i:sh option
+while getopts f:i:shu option
 do
 	case "$option" in
 		f)
@@ -61,16 +61,15 @@ RunJava()
 
 	START_TIME=0
 	if [[ "$USEFILE" == true ]]; then
-		START_TIME=$(($(date $DATE_MOD)/1000000))
+		START_TIME=$(($($DATE_COMMAND +%s%N)/1000000))
 		java "$NAME" < "$IN_FILE"
 	else
-		START_TIME=$(($(date $DATE_MOD)/1000000))
-		java "$NAME" < "$IN_FILE"
+		START_TIME=$(($($DATE_COMMAND +%s%N)/1000000))
+		java "$NAME"
 	fi
-	END_TIME=$(($(date $DATE_MOD)/1000000))
+	END_TIME=$(($($DATE_COMMAND +%s%N)/1000000))
 	ELAPSED_TIME=$(($END_TIME - $START_TIME))
 	echo -e "${GREEN}Runtime: ${ELAPSED_TIME} ms"
-
 	echo -e "${GREEN}Removing class file..."
 	rm *.class
 	echo -e "${GREEN}Done"


### PR DESCRIPTION
Added:
* Proper macOS support (at least if `coreutils` is there)
* Flag to specify an input file
* Flag to skip compilation
* Set the "use stdin" flag to `-u` in order to use `-i` for specifying input file  
* Difference comparison